### PR TITLE
ZCS-14269: Use private docker images registry instead of public registry.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,10 @@ jobs:
     working_directory: ~/repo
     shell: /bin/bash -eo pipefail
     docker:
-      - image: zimbra/zm-base-os:devcore-ubuntu-18.04
+         - image: $DOCKER_REGISTRY/zm-base-os:devcore-ubuntu-18.04
+           auth:
+            username: $DOCKER_USER
+            password: $DOCKER_PASS
     steps:
       - package-builder
 
@@ -124,7 +127,10 @@ jobs:
     working_directory: ~/repo
     shell: /bin/bash -eo pipefail
     docker:
-      - image: zimbra/zm-base-os:devcore-ubuntu-16.04
+         - image: $DOCKER_REGISTRY/zm-base-os:devcore-ubuntu-16.04
+           auth:
+            username: $DOCKER_USER
+            password: $DOCKER_PASS
     steps:
       - package-builder
 
@@ -132,7 +138,10 @@ jobs:
     working_directory: ~/repo
     shell: /bin/bash -eo pipefail
     docker:
-      - image: zimbra/zm-base-os:devcore-ubuntu-14.04
+         - image: $DOCKER_REGISTRY/zm-base-os:devcore-ubuntu-14.04
+           auth:
+            username: $DOCKER_USER
+            password: $DOCKER_PASS
     steps:
       - package-builder
 
@@ -140,7 +149,10 @@ jobs:
     working_directory: ~/repo
     shell: /bin/bash -eo pipefail
     docker:
-      - image: zimbra/zm-base-os:devcore-centos-8
+         - image: $DOCKER_REGISTRY/zm-base-os:devcore-centos-8
+           auth:
+            username: $DOCKER_USER
+            password: $DOCKER_PASS
     steps:
       - package-builder
 
@@ -148,7 +160,10 @@ jobs:
     working_directory: ~/repo
     shell: /bin/bash -eo pipefail
     docker:
-      - image: zimbra/zm-base-os:devcore-centos-7
+         - image: $DOCKER_REGISTRY/zm-base-os:devcore-centos-7
+           auth:
+            username: $DOCKER_USER
+            password: $DOCKER_PASS
     steps:
       - package-builder
 
@@ -156,7 +171,10 @@ jobs:
     working_directory: ~/repo
     shell: /bin/bash -eo pipefail
     docker:
-      - image: zimbra/zm-base-os:devcore-centos-6
+         - image: $DOCKER_REGISTRY/zm-base-os:devcore-centos-6
+           auth:
+            username: $DOCKER_USER
+            password: $DOCKER_PASS
     steps:
       - package-builder
 
@@ -213,26 +231,38 @@ workflows:
       - build-u18:
           requires:
             - zip
+          context:
+            - docker-dev-registry
 
       - build-u16:
           requires:
             - zip
+          context:
+            - docker-dev-registry
 
       - build-u14:
           requires:
             - zip
+          context:
+            - docker-dev-registry
 
       - build-c8:
           requires:
             - zip
+          context:
+            - docker-dev-registry
 
       - build-c7:
           requires:
             - zip
+          context:
+            - docker-dev-registry
 
       - build-c6:
           requires:
             - zip
+          context:
+            - docker-dev-registry
 
       - deploy-s3-approval:
           type: approval


### PR DESCRIPTION
**ZCS-14269: Use private docker images registry instead of public registry.**

- Using synacor's OCI dev/ image registry to pull images instead of using images from zimbra/zm-base-os public docker registry.